### PR TITLE
Update to return loaded record even when primary keys are default values

### DIFF
--- a/src/Gemstone.Data/AdoDataConnection.cs
+++ b/src/Gemstone.Data/AdoDataConnection.cs
@@ -960,6 +960,62 @@ public class AdoDataConnection : IAsyncDisposable, IDisposable
     }
 
     /// <summary>
+    /// Tries to retrieve the first <see cref="DataRow"/> in the result set of the SQL statement using <see cref="Connection"/>.
+    /// </summary>
+    /// <param name="sqlFormat">Format string for the SQL statement to be executed.</param>
+    /// <param name="row">The first <see cref="DataRow"/> in the result set, or <c>null</c>.</param>
+    /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters.</param>
+    /// <returns>The first <see cref="DataRow"/> in the result set.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryRetrieveRow(string sqlFormat, out DataRow? row, params object?[] parameters)
+    {
+        return TryRetrieveRow(DefaultTimeout, sqlFormat, out row, parameters);
+    }
+
+    /// <summary>
+    /// Tries to retrieve the first <see cref="DataRow"/> in the result set of the SQL statement using <see cref="Connection"/>.
+    /// </summary>
+    /// <param name="sqlFormat">Format string for the SQL statement to be executed.</param>
+    /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+    /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters.</param>
+    /// <returns>Tuple of first <see cref="DataRow"/> in the result set (can be <c>null</c>) and a flag that determines if retrieve was successful.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task<(DataRow?, bool)> TryRetrieveRowAsync(string sqlFormat, CancellationToken cancellationToken, params object?[] parameters)
+    {
+        return TryRetrieveRowAsync(DefaultTimeout, sqlFormat, cancellationToken, parameters);
+    }
+
+    /// <summary>
+    /// Tries to retrieve the first <see cref="DataRow"/> in the result set of the SQL statement using <see cref="Connection"/>.
+    /// </summary>
+    /// <param name="sqlFormat">Format string for the SQL statement to be executed.</param>
+    /// <param name="timeout">The time in seconds to wait for the SQL statement to execute.</param>
+    /// <param name="row">The first <see cref="DataRow"/> in the result set, or <c>null</c>.</param>
+    /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters.</param>
+    /// <returns>The first <see cref="DataRow"/> in the result set.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryRetrieveRow(int timeout, string sqlFormat, out DataRow? row, params object?[] parameters)
+    {
+        string sql = GenericParameterizedQueryString(sqlFormat, parameters);
+        return Connection.TryRetrieveRow(sql, timeout, out row, ResolveParameters(parameters));
+    }
+
+    /// <summary>
+    /// Tries to retrieve the first <see cref="DataRow"/> in the result set of the SQL statement using <see cref="Connection"/>.
+    /// </summary>
+    /// <param name="sqlFormat">Format string for the SQL statement to be executed.</param>
+    /// <param name="timeout">The time in seconds to wait for the SQL statement to execute.</param>
+    /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+    /// <param name="parameters">The parameter values to be used to fill in <see cref="IDbDataParameter"/> parameters.</param>
+    /// <returns>Tuple of first <see cref="DataRow"/> in the result set (can be <c>null</c>) and a flag that determines if retrieve was successful.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Task<(DataRow?, bool)> TryRetrieveRowAsync(int timeout, string sqlFormat, CancellationToken cancellationToken, params object?[] parameters)
+    {
+        string sql = GenericParameterizedQueryString(sqlFormat, parameters);
+        return Connection.TryRetrieveRowAsync(sql, timeout, cancellationToken, ResolveParameters(parameters));
+    }
+
+    /// <summary>
     /// Executes the SQL statement using <see cref="Connection"/>, and returns the first <see cref="DataTable"/> 
     /// of result set, if the result set contains at least one table.
     /// </summary>
@@ -1333,7 +1389,7 @@ public class AdoDataConnection : IAsyncDisposable, IDisposable
     public string ParameterizedQueryString(string format, params string[] parameterNames)
     {
         char paramChar = IsOracle ? ':' : '@';
-        object[] parameters = parameterNames.Select(name => paramChar + name).Cast<object>().ToArray();
+        object?[] parameters = parameterNames.Select(name => paramChar + name).Cast<object>().ToArray();
 
         return string.Format(format, parameters);
     }

--- a/src/Gemstone.Data/DataExtensions/DataExtensions.cs
+++ b/src/Gemstone.Data/DataExtensions/DataExtensions.cs
@@ -848,6 +848,70 @@ public static class DataExtensions
     }
 
     /// <summary>
+    /// Tries to retrieve the first <see cref="DataRow"/> in the result set of the SQL statement using <see cref="DbConnection"/>.
+    /// </summary>
+    /// <param name="connection">The <see cref="DbConnection"/> to use for executing the SQL statement.</param>
+    /// <param name="sql">The SQL statement to be executed.</param>
+    /// <param name="row">The first <see cref="DataRow"/> in the result set, or <c>null</c>.</param>
+    /// <param name="parameters">The parameter values to be used to fill in <see cref="DbParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
+    /// <returns>The first <see cref="DataRow"/> in the result set.</returns>
+    public static bool TryRetrieveRow(this DbConnection connection, string sql, out DataRow? row, params object[] parameters)
+    {
+        return connection.TryRetrieveRow(sql, DefaultTimeoutDuration, out row, parameters);
+    }
+
+    /// <summary>
+    /// Tries to retrieve the first <see cref="DataRow"/> in the result set of the SQL statement using <see cref="DbConnection"/>.
+    /// </summary>
+    /// <param name="connection">The <see cref="DbConnection"/> to use for executing the SQL statement.</param>
+    /// <param name="sql">The SQL statement to be executed.</param>
+    /// <param name="timeout">The time in seconds to wait for the SQL statement to execute.</param>
+    /// <param name="row">The first <see cref="DataRow"/> in the result set, or <c>null</c>.</param>
+    /// <param name="parameters">The parameter values to be used to fill in <see cref="DbParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
+    /// <returns>The first <see cref="DataRow"/> in the result set.</returns>
+    public static bool TryRetrieveRow(this DbConnection connection, string sql, int timeout, out DataRow? row, params object[] parameters)
+    {
+        DataTable dataTable = connection.RetrieveData(sql, timeout, parameters);
+
+        if (dataTable.Rows.Count == 0)
+        {
+            row = default;
+            return false;
+        }
+
+        row = dataTable.Rows[0];
+        return true;
+    }
+
+    /// <summary>
+    /// Tries to retrieve the first <see cref="DataRow"/> in the result set of the SQL statement using <see cref="DbConnection"/>.
+    /// </summary>
+    /// <param name="connection">The <see cref="DbConnection"/> to use for executing the SQL statement.</param>
+    /// <param name="sql">The SQL statement to be executed.</param>
+    /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+    /// <param name="parameters">The parameter values to be used to fill in <see cref="DbParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
+    /// <returns>Tuple of first <see cref="DataRow"/> in the result set (can be <c>null</c>) and a flag that determines if retrieve was successful.</returns>
+    public static Task<(DataRow? row, bool)> TryRetrieveRowAsync(this DbConnection connection, string sql, CancellationToken cancellationToken, params object[] parameters)
+    {
+        return connection.TryRetrieveRowAsync(sql, DefaultTimeoutDuration, cancellationToken, parameters);
+    }
+
+    /// <summary>
+    /// Tries to retrieve the first <see cref="DataRow"/> in the result set of the SQL statement using <see cref="DbConnection"/>.
+    /// </summary>
+    /// <param name="connection">The <see cref="DbConnection"/> to use for executing the SQL statement.</param>
+    /// <param name="sql">The SQL statement to be executed.</param>
+    /// <param name="timeout">The time in seconds to wait for the SQL statement to execute.</param>
+    /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+    /// <param name="parameters">The parameter values to be used to fill in <see cref="DbParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
+    /// <returns>Tuple of first <see cref="DataRow"/> in the result set (can be <c>null</c>) and a flag that determines if retrieve was successful.</returns>
+    public static async Task<(DataRow? row, bool)> TryRetrieveRowAsync(this DbConnection connection, string sql, int timeout, CancellationToken cancellationToken, params object[] parameters)
+    {
+        DataTable dataTable = await connection.RetrieveDataAsync(timeout, sql, cancellationToken, parameters).ConfigureAwait(false);
+        return dataTable.Rows.Count == 0 ? (default, false) : (dataTable.Rows[0], true);
+    }
+
+    /// <summary>
     /// Executes the SQL statement using <see cref="DbCommand"/>, and returns the first <see cref="DataRow"/> in the result set.
     /// </summary>
     /// <param name="command">The <see cref="DbCommand"/> to use for executing the SQL statement.</param>
@@ -911,6 +975,70 @@ public static class DataExtensions
             dataTable.Rows.Add(dataTable.NewRow());
 
         return dataTable.Rows[0];
+    }
+
+    /// <summary>
+    /// Tries to retrieve the first <see cref="DataRow"/> in the result set of the SQL statement using <see cref="DbCommand"/>.
+    /// </summary>
+    /// <param name="command">The <see cref="DbCommand"/> to use for executing the SQL statement.</param>
+    /// <param name="sql">The SQL statement to be executed.</param>
+    /// <param name="row">The first <see cref="DataRow"/> in the result set, or <c>null</c>.</param>
+    /// <param name="parameters">The parameter values to be used to fill in <see cref="DbParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
+    /// <returns>The first <see cref="DataRow"/> in the result set.</returns>
+    public static bool TryRetrieveRow(this DbCommand command, string sql, out DataRow? row, params object[] parameters)
+    {
+        return command.TryRetrieveRow(sql, DefaultTimeoutDuration, out row, parameters);
+    }
+
+    /// <summary>
+    /// Tries to retrieve the first <see cref="DataRow"/> in the result set of the SQL statement using <see cref="DbCommand"/>.
+    /// </summary>
+    /// <param name="command">The <see cref="DbCommand"/> to use for executing the SQL statement.</param>
+    /// <param name="sql">The SQL statement to be executed.</param>
+    /// <param name="timeout">The time in seconds to wait for the SQL statement to execute.</param>
+    /// <param name="row">The first <see cref="DataRow"/> in the result set, or <c>null</c>.</param>
+    /// <param name="parameters">The parameter values to be used to fill in <see cref="DbParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
+    /// <returns>The first <see cref="DataRow"/> in the result set.</returns>
+    public static bool TryRetrieveRow(this DbCommand command, string sql, int timeout, out DataRow? row, params object[] parameters)
+    {
+        DataTable dataTable = command.RetrieveData(sql, timeout, parameters);
+
+        if (dataTable.Rows.Count == 0)
+        {
+            row = default;
+            return false;
+        }
+
+        row = dataTable.Rows[0];
+        return true;
+    }
+
+    /// <summary>
+    /// Tries to retrieve the first <see cref="DataRow"/> in the result set of the SQL statement using <see cref="DbCommand"/>.
+    /// </summary>
+    /// <param name="command">The <see cref="DbCommand"/> to use for executing the SQL statement.</param>
+    /// <param name="sql">The SQL statement to be executed.</param>
+    /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+    /// <param name="parameters">The parameter values to be used to fill in <see cref="DbParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
+    /// <returns>Tuple of first <see cref="DataRow"/> in the result set (can be <c>null</c>) and a flag that determines if retrieve was successful.</returns>
+    public static Task<(DataRow? row, bool)> TryRetrieveRowAsync(this DbCommand command, string sql, CancellationToken cancellationToken, params object[] parameters)
+    {
+        return command.TryRetrieveRowAsync(sql, DefaultTimeoutDuration, cancellationToken, parameters);
+    }
+
+    /// <summary>
+    /// Tries to retrieve the first <see cref="DataRow"/> in the result set of the SQL statement using <see cref="DbCommand"/>.
+    /// </summary>
+    /// <param name="command">The <see cref="DbCommand"/> to use for executing the SQL statement.</param>
+    /// <param name="sql">The SQL statement to be executed.</param>
+    /// <param name="timeout">The time in seconds to wait for the SQL statement to execute.</param>
+    /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
+    /// <param name="parameters">The parameter values to be used to fill in <see cref="DbParameter"/> parameters identified by '@' prefix in <paramref name="sql"/> expression.</param>
+    /// <returns>Tuple of first <see cref="DataRow"/> in the result set (can be <c>null</c>) and a flag that determines if retrieve was successful.</returns>
+    public static async Task<(DataRow? row, bool)> TryRetrieveRowAsync(this DbCommand command, string sql, int timeout, CancellationToken cancellationToken, params object[] parameters)
+    {
+        DataTable dataTable = await command.RetrieveDataAsync(timeout, sql, cancellationToken, parameters).ConfigureAwait(false);
+        return dataTable.Rows.Count == 0 ? (default, false) : (dataTable.Rows[0], true);
     }
 
     #endregion


### PR DESCRIPTION
Synchronization with GSF update.

Note that function of `AddNewOrUpdateRecord` is still dependent on detection of default primary keys values.

If a model use intends to insert a record with default values for primary keys, user will need to manually differentiate between "add" and "update" operation in code and not use `AddNewOrUpdateRecord` function in this scenario.