### PR TITLE
Include orderBy expression validation

### DIFF
--- a/src/Gemstone.Data.sln.DotSettings
+++ b/src/Gemstone.Data.sln.DotSettings
@@ -1,3 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=An_0020enumerable_0020of/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/GrammarAndSpelling/GrammarChecking/Exceptions/=_007D/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lackner/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=unescaping/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Gemstone.Data/AdoDataConnection.cs
+++ b/src/Gemstone.Data/AdoDataConnection.cs
@@ -293,7 +293,7 @@ public class AdoDataConnection : IAsyncDisposable, IDisposable
     /// <summary>
     /// Gets an open <see cref="DbConnection"/> to configured ADO.NET data source.
     /// </summary>
-    public DbConnection Connection { get; } = default!;
+    public DbConnection Connection { get; } = null!;
 
     /// <summary>
     /// Gets or sets the type of the database underlying the <see cref="AdoDataConnection"/>.
@@ -729,7 +729,7 @@ public class AdoDataConnection : IAsyncDisposable, IDisposable
     {
         return returnType.IsValueType ? 
             ExecuteScalar(returnType, Activator.CreateInstance(returnType), timeout, sqlFormat, parameters) : 
-            ExecuteScalar(returnType, (object)default!, timeout, sqlFormat, parameters);
+            ExecuteScalar(returnType, (object)null!, timeout, sqlFormat, parameters);
     }
 
     /// <summary>
@@ -747,7 +747,7 @@ public class AdoDataConnection : IAsyncDisposable, IDisposable
     {
         return returnType.IsValueType ?
             ExecuteScalarAsync(returnType, Activator.CreateInstance(returnType), timeout, sqlFormat, cancellationToken, parameters) :
-            ExecuteScalarAsync(returnType, default!, timeout, sqlFormat, cancellationToken, parameters);
+            ExecuteScalarAsync(returnType, null!, timeout, sqlFormat, cancellationToken, parameters);
     }
 
     /// <summary>

--- a/src/Gemstone.Data/BulkDataOperationBase.cs
+++ b/src/Gemstone.Data/BulkDataOperationBase.cs
@@ -254,7 +254,7 @@ public abstract class BulkDataOperationBase : IBulkDataOperation, IDisposable
     /// <summary>
     /// Get list of tables to be excluded during data processing
     /// </summary>
-    public List<string> ExcludedTables { get; } = new();
+    public List<string> ExcludedTables { get; } = [];
 
     #endregion
 

--- a/src/Gemstone.Data/DataDeleter.cs
+++ b/src/Gemstone.Data/DataDeleter.cs
@@ -98,7 +98,7 @@ public class DataDeleter : BulkDataOperationBase
     /// </summary>
     public override void Execute()
     {
-        List<Table> tablesList = new();
+        List<Table> tablesList = [];
         int x;
 
         if (TableCollection.Count == 0)

--- a/src/Gemstone.Data/DataExtensions/DataExtensions.cs
+++ b/src/Gemstone.Data/DataExtensions/DataExtensions.cs
@@ -875,7 +875,7 @@ public static class DataExtensions
 
         if (dataTable.Rows.Count == 0)
         {
-            row = default;
+            row = null;
             return false;
         }
 
@@ -908,7 +908,7 @@ public static class DataExtensions
     public static async Task<(DataRow? row, bool)> TryRetrieveRowAsync(this DbConnection connection, string sql, int timeout, CancellationToken cancellationToken, params object[] parameters)
     {
         DataTable dataTable = await connection.RetrieveDataAsync(timeout, sql, cancellationToken, parameters).ConfigureAwait(false);
-        return dataTable.Rows.Count == 0 ? (default, false) : (dataTable.Rows[0], true);
+        return dataTable.Rows.Count == 0 ? (null, false) : (dataTable.Rows[0], true);
     }
 
     /// <summary>
@@ -1005,7 +1005,7 @@ public static class DataExtensions
 
         if (dataTable.Rows.Count == 0)
         {
-            row = default;
+            row = null;
             return false;
         }
 
@@ -1038,7 +1038,7 @@ public static class DataExtensions
     public static async Task<(DataRow? row, bool)> TryRetrieveRowAsync(this DbCommand command, string sql, int timeout, CancellationToken cancellationToken, params object[] parameters)
     {
         DataTable dataTable = await command.RetrieveDataAsync(timeout, sql, cancellationToken, parameters).ConfigureAwait(false);
-        return dataTable.Rows.Count == 0 ? (default, false) : (dataTable.Rows[0], true);
+        return dataTable.Rows.Count == 0 ? (null, false) : (dataTable.Rows[0], true);
     }
 
     #endregion
@@ -1421,7 +1421,7 @@ public static class DataExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static object? ConvertField(this DataRow row, string field, Type type)
     {
-        return ConvertField(row, field, type, default!);
+        return ConvertField(row, field, type, null!);
     }
 
     /// <summary>

--- a/src/Gemstone.Data/DataInserter.cs
+++ b/src/Gemstone.Data/DataInserter.cs
@@ -201,7 +201,7 @@ public class DataInserter : BulkDataOperationBase
     /// </summary>
     public override void Execute()
     {
-        List<Table> tablesList = new();
+        List<Table> tablesList = [];
         Table tableLookup;
         Table table;
         int x;
@@ -219,7 +219,7 @@ public class DataInserter : BulkDataOperationBase
         if (ClearDestinationTables)
         {
             // We do not consider table exclusions when deleting data from destination tables as these may have triggered inserts
-            List<Table> allSourceTables = new(FromSchema.Tables);
+            List<Table> allSourceTables = [..FromSchema.Tables];
 
             // Clear data in a child to parent direction to help avoid potential constraint issues
             allSourceTables.Sort((table1, table2) => table1.Priority > table2.Priority ? 1 : table1.Priority < table2.Priority ? -1 : 0);
@@ -828,7 +828,7 @@ public class DataInserter : BulkDataOperationBase
             if (BulkInsertFilePath.Substring(BulkInsertFilePath.Length - 1) != "\\")
                 BulkInsertFilePath += "\\";
 
-            bulkInsertFile = $"{BulkInsertFilePath}{new Guid()}.tmp";
+            bulkInsertFile = $"{BulkInsertFilePath}{Guid.Empty}.tmp";
             bulkInsertFileStream = File.Create(bulkInsertFile);
         }
 

--- a/src/Gemstone.Data/DataSetExtensions/DataSetExtensions.cs
+++ b/src/Gemstone.Data/DataSetExtensions/DataSetExtensions.cs
@@ -190,8 +190,8 @@ public static class DataSetExtensions
         // Serialize tables
         foreach (DataTable table in source.Tables)
         {
-            List<int> columnIndices = new();
-            List<DataType> columnDataTypes = new();
+            List<int> columnIndices = [];
+            List<DataType> columnDataTypes = [];
 
             // Serialize column metadata
             using (BlockAllocatedMemoryStream columnMetaDataStream = new())
@@ -361,9 +361,9 @@ public static class DataSetExtensions
         // Deserialize tables
         for (int i = 0; i < tableCount; i++)
         {
-            List<int> columnIndices = new();
-            List<DataType> columnDataTypes = new();
-            List<bool> columnNullable = new();
+            List<int> columnIndices = [];
+            List<DataType> columnDataTypes = [];
+            List<bool> columnNullable = [];
 
             DataTable table = dataset.Tables.Add();
 

--- a/src/Gemstone.Data/DataUpdater.cs
+++ b/src/Gemstone.Data/DataUpdater.cs
@@ -98,7 +98,7 @@ public class DataUpdater : BulkDataOperationBase
     /// </summary>
     public override void Execute()
     {
-        List<Table> tablesList = new();
+        List<Table> tablesList = [];
         int x;
 
         if (TableCollection.Count == 0)

--- a/src/Gemstone.Data/Model/DefaultSortOrderAttribute.cs
+++ b/src/Gemstone.Data/Model/DefaultSortOrderAttribute.cs
@@ -34,11 +34,7 @@ public sealed class DefaultSortOrderAttribute : Attribute
     /// <summary>
     /// Gets field name to use for property.
     /// </summary>
-    public bool Ascending
-    {
-        get;
-    }
-
+    public bool Ascending { get; }
 
     /// <summary>
     /// Creates a new <see cref="DefaultSortOrderAttribute"/>.

--- a/src/Gemstone.Data/Model/DeleteRolesAttribute.cs
+++ b/src/Gemstone.Data/Model/DeleteRolesAttribute.cs
@@ -34,10 +34,7 @@ public sealed class DeleteRolesAttribute : Attribute
     /// <summary>
     /// Gets field name to use for property.
     /// </summary>
-    public string Roles
-    {
-        get;
-    }
+    public string Roles { get; }
 
     /// <summary>
     /// Creates a new <see cref="DeleteRolesAttribute"/>.

--- a/src/Gemstone.Data/Model/EncryptDataAttribute.cs
+++ b/src/Gemstone.Data/Model/EncryptDataAttribute.cs
@@ -53,8 +53,8 @@ public sealed class EncryptDataAttribute : Attribute
     /// </summary>
     public EncryptDataAttribute()
     {
-            KeyReference = DefaultKeyReference;
-        }
+        KeyReference = DefaultKeyReference;
+    }
 
     /// <summary>
     /// Creates a new <see cref="EncryptDataAttribute"/> with a specified <paramref name="keyReference"/> value.
@@ -62,9 +62,9 @@ public sealed class EncryptDataAttribute : Attribute
     /// <param name="keyReference">Reference name used to lookup encryption key and initialization vector.</param>
     public EncryptDataAttribute(string keyReference)
     {
-            if (string.IsNullOrWhiteSpace(keyReference))
-                throw new ArgumentNullException(nameof(keyReference), "Key reference cannot be null, empty or whitespace.");
+        if (string.IsNullOrWhiteSpace(keyReference))
+            throw new ArgumentNullException(nameof(keyReference), "Key reference cannot be null, empty or whitespace.");
 
-            KeyReference = keyReference;
-        }
+        KeyReference = keyReference;
+    }
 }

--- a/src/Gemstone.Data/Model/ExtensionAttributeBase.cs
+++ b/src/Gemstone.Data/Model/ExtensionAttributeBase.cs
@@ -1,7 +1,7 @@
 ﻿//******************************************************************************************************
-//  PostRolesAttribute.cs - Gbtc
+//  ExtensionAttributeBase.cs - Gbtc
 //
-//  Copyright © 2021, Grid Protection Alliance.  All Rights Reserved.
+//  Copyright © 2025, Grid Protection Alliance.  All Rights Reserved.
 //
 //  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
 //  the NOTICE file distributed with this work for additional information regarding copyright ownership.
@@ -16,7 +16,7 @@
 //
 //  Code Modification History:
 //  ----------------------------------------------------------------------------------------------------
-//  06/11/2021 - Billy Ernest
+//  03/27/2025 - J. Ritchie Carroll
 //       Generated original version of source code.
 //
 //******************************************************************************************************
@@ -26,22 +26,22 @@ using System;
 namespace Gemstone.Data.Model;
 
 /// <summary>
-/// Defines an attribute that will allow setting POST function roles for a modeled table.
+/// Base class for Attributes that are used to extend the functionality of <see cref="TableOperations{T}"/>.
 /// </summary>
-[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
-public sealed class PostRolesAttribute : Attribute
+[AttributeUsage(AttributeTargets.Method)]
+public abstract class ExtensionAttributeBase : Attribute
 {
     /// <summary>
-    /// Gets field name to use for property.
+    /// The regular expression used to match field names the attribute applies to.
     /// </summary>
-    public string Roles { get; }
+    public string FieldMatch { get; }
 
     /// <summary>
-    /// Creates a new <see cref="PostRolesAttribute"/>.
+    /// Creates a new <see cref="ExtensionAttributeBase"/>
     /// </summary>
-    /// <param name="roles">Comma separated string of roles allowed for POST functions.</param>
-    public PostRolesAttribute(string roles)
+    /// <param name="fieldMatch">Field match expression for the attribute.</param>
+    protected ExtensionAttributeBase(string fieldMatch)
     {
-        Roles = roles;
+        FieldMatch = fieldMatch;
     }
 }

--- a/src/Gemstone.Data/Model/FieldNameAttribute.cs
+++ b/src/Gemstone.Data/Model/FieldNameAttribute.cs
@@ -45,6 +45,6 @@ public sealed class FieldNameAttribute : Attribute
     /// <param name="fieldName">Field name to use for property.</param>
     public FieldNameAttribute(string fieldName)
     {
-            FieldName = fieldName;
-        }
+        FieldName = fieldName;
+    }
 }

--- a/src/Gemstone.Data/Model/GetRolesAttribute.cs
+++ b/src/Gemstone.Data/Model/GetRolesAttribute.cs
@@ -34,10 +34,7 @@ public sealed class GetRolesAttribute : Attribute
     /// <summary>
     /// Gets field name to use for property.
     /// </summary>
-    public string Roles
-    {
-        get;
-    }
+    public string Roles { get; }
 
     /// <summary>
     /// Creates a new <see cref="GetRolesAttribute"/>.

--- a/src/Gemstone.Data/Model/ITableOperations.cs
+++ b/src/Gemstone.Data/Model/ITableOperations.cs
@@ -62,6 +62,7 @@ public interface ITableOperations
     /// Gets the wildcard character used for pattern matching within queries.
     /// </summary>
     public string WildcardChar { get; }
+
     /// <summary>
     /// Gets flag that determines if modeled table has a primary key that is an identity field.
     /// </summary>
@@ -92,7 +93,7 @@ public interface ITableOperations
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The <see cref="QueryRecords(string, bool, int, int, IRecordFilter[])"/> overloads that include paging parameters
+    /// The <see cref="QueryRecords(string?, bool, int, int, IRecordFilter[])"/> overloads that include paging parameters
     /// cache the sorted and filtered primary keys of queried records between calls so that paging is fast and
     /// efficient. Since the primary keys are cached, an instance of the <see cref="TableOperations{T}"/> should
     /// exist per user session when using query functions that support pagination. In web based implementations,
@@ -204,7 +205,7 @@ public interface ITableOperations
     /// If no record is found for specified <paramref name="restriction"/>, <c>null</c> will be returned.
     /// </para>
     /// <para>
-    /// This is a convenience call to <see cref="QueryRecords(string, RecordRestriction, int)"/>
+    /// This is a convenience call to <see cref="QueryRecords(string?, RecordRestriction, int)"/>
     /// specifying the <see cref="RecordRestriction"/> parameter with a limit of 1 record.
     /// </para>
     /// <para>
@@ -227,7 +228,7 @@ public interface ITableOperations
     /// If no record is found for specified <paramref name="restriction"/>, <c>null</c> will be returned.
     /// </para>
     /// <para>
-    /// This is a convenience call to <see cref="QueryRecords(string, RecordRestriction, int)"/>
+    /// This is a convenience call to <see cref="QueryRecords(string?, RecordRestriction, int)"/>
     /// specifying the <see cref="RecordRestriction"/> parameter with a limit of 1 record.
     /// </para>
     /// <para>
@@ -251,7 +252,7 @@ public interface ITableOperations
     /// If no record is found for specified <paramref name="restriction"/>, <c>null</c> will be returned.
     /// </para>
     /// <para>
-    /// This is a convenience call to <see cref="QueryRecords(string, RecordRestriction, int)"/>
+    /// This is a convenience call to <see cref="QueryRecords(string?, RecordRestriction, int)"/>
     /// specifying the <see cref="RecordRestriction"/> parameter with a limit of 1 record.
     /// </para>
     /// <para>
@@ -276,7 +277,7 @@ public interface ITableOperations
     /// If no record is found for specified <paramref name="restriction"/>, <c>null</c> will be returned.
     /// </para>
     /// <para>
-    /// This is a convenience call to <see cref="QueryRecords(string, RecordRestriction, int)"/>
+    /// This is a convenience call to <see cref="QueryRecords(string?, RecordRestriction, int)"/>
     /// specifying the <see cref="RecordRestriction"/> parameter with a limit of 1 record.
     /// </para>
     /// <para>
@@ -319,7 +320,7 @@ public interface ITableOperations
     /// will be updated to reflect what is defined in the user model.
     /// </para>
     /// <para>
-    /// This is a convenience call to <see cref="QueryRecords(string, RecordRestriction, int)"/>
+    /// This is a convenience call to <see cref="QueryRecords(string?, RecordRestriction, int)"/>
     /// specifying the <see cref="RecordRestriction"/> parameter with a limit of 1 record.
     /// </para>
     /// </remarks>
@@ -357,7 +358,7 @@ public interface ITableOperations
     /// will be updated to reflect what is defined in the user model.
     /// </para>
     /// <para>
-    /// This is a convenience call to <see cref="QueryRecords(string, RecordRestriction, int)"/>
+    /// This is a convenience call to <see cref="QueryRecords(string?, RecordRestriction, int)"/>
     /// specifying the <see cref="RecordRestriction"/> parameter with a limit of 1 record.
     /// </para>
     /// </remarks>
@@ -411,7 +412,7 @@ public interface ITableOperations
     /// <returns>An enumerable of modeled table row instances for queried records.</returns>
     /// <remarks>
     /// <para>
-    /// This is a convenience call to <see cref="QueryRecords(string, RecordRestriction, int)"/> only
+    /// This is a convenience call to <see cref="QueryRecords(string?, RecordRestriction, int)"/> only
     /// specifying the <see cref="RecordRestriction"/> parameter.
     /// </para>
     /// <para>
@@ -431,7 +432,7 @@ public interface ITableOperations
     /// <returns>An enumerable of modeled table row instances for queried records.</returns>
     /// <remarks>
     /// <para>
-    /// This is a convenience call to <see cref="QueryRecords(string, RecordRestriction, int)"/> only
+    /// This is a convenience call to <see cref="QueryRecords(string?, RecordRestriction, int)"/> only
     /// specifying the <see cref="RecordRestriction"/> parameter.
     /// </para>
     /// <para>
@@ -471,7 +472,7 @@ public interface ITableOperations
     /// will be updated to reflect what is defined in the user model.
     /// </para>
     /// <para>
-    /// This is a convenience call to <see cref="QueryRecords(string, RecordRestriction, int)"/> only
+    /// This is a convenience call to <see cref="QueryRecords(string?, RecordRestriction, int)"/> only
     /// specifying the <see cref="RecordRestriction"/> parameter.
     /// </para>
     /// </remarks>
@@ -506,7 +507,7 @@ public interface ITableOperations
     /// will be updated to reflect what is defined in the user model.
     /// </para>
     /// <para>
-    /// This is a convenience call to <see cref="QueryRecords(string, RecordRestriction, int)"/> only
+    /// This is a convenience call to <see cref="QueryRecords(string?, RecordRestriction, int)"/> only
     /// specifying the <see cref="RecordRestriction"/> parameter.
     /// </para>
     /// </remarks>
@@ -579,7 +580,7 @@ public interface ITableOperations
     /// be downloaded locally and decrypted so the proper sort order can be determined.
     /// </para>
     /// <para>
-    /// This is a convenience call to <see cref="QueryRecords(string, bool, int, int, RecordRestriction[])"/> where restriction
+    /// This is a convenience call to <see cref="QueryRecords(string?, bool, int, int, RecordRestriction[])"/> where restriction
     /// is generated by <see cref="GetSearchRestrictions"/> using <paramref name="recordFilters"/>.
     /// </para>
     /// </remarks>
@@ -608,7 +609,7 @@ public interface ITableOperations
     /// be downloaded locally and decrypted so the proper sort order can be determined.
     /// </para>
     /// <para>
-    /// This is a convenience call to <see cref="QueryRecords(string, bool, int, int, RecordRestriction[])"/> where restriction
+    /// This is a convenience call to <see cref="QueryRecords(string?, bool, int, int, RecordRestriction[])"/> where restriction
     /// is generated by <see cref="GetSearchRestrictions(IRecordFilter[])"/> using <paramref name="recordFilters"/>.
     /// </para>
     /// </remarks>
@@ -830,7 +831,7 @@ public interface ITableOperations
     /// This function searches records locally after query from database, this way Search functionality will work
     /// even with fields that are modeled with the <see cref="EncryptDataAttribute"/> and use restrictions not being = or =/=.
     /// Primary keys for this function will not be cached server-side and this function will be slower and more expensive than similar calls
-    /// to <see cref="QueryRecords(string, bool, int, int, IRecordFilter[])"/>. Usage should be restricted to cases searching for field data that has
+    /// to <see cref="QueryRecords(string?, bool, int, int, IRecordFilter[])"/>. Usage should be restricted to cases searching for field data that has
     /// been modeled with the <see cref="EncryptDataAttribute"/>.
     /// </para>
     /// <para>
@@ -838,7 +839,7 @@ public interface ITableOperations
     /// through them using the <see cref="GetPageOfRecords"/> function. As a result, usage should be restricted to smaller data sets. 
     /// </para>
     /// </remarks>
-    object?[]? SearchRecords(string sortField, bool ascending, StringComparison comparison = StringComparison.OrdinalIgnoreCase, params IRecordFilter?[]? recordFilters);
+    object?[]? SearchRecords(string? sortField, bool ascending, StringComparison comparison = StringComparison.OrdinalIgnoreCase, params IRecordFilter?[]? recordFilters);
 
     /// <summary>
     /// Locally searches retrieved table records after queried from database for the specified sorting and search parameters.
@@ -856,7 +857,7 @@ public interface ITableOperations
     /// This function searches records locally after query from database, this way Search functionality will work
     /// even with fields that are modeled with the <see cref="EncryptDataAttribute"/> and use restrictions not being = or =/=.
     /// Primary keys for this function will not be cached server-side and this function will be slower and more expensive than similar calls
-    /// to <see cref="QueryRecords(string, bool, int, int, IRecordFilter[])"/>. Usage should be restricted to cases searching for field data that has
+    /// to <see cref="QueryRecords(string?, bool, int, int, IRecordFilter[])"/>. Usage should be restricted to cases searching for field data that has
     /// been modeled with the <see cref="EncryptDataAttribute"/>.
     /// </para>
     /// <para>
@@ -864,7 +865,7 @@ public interface ITableOperations
     /// through them using the <see cref="GetPageOfRecordsAsync"/> function. As a result, usage should be restricted to smaller data sets. 
     /// </para>
     /// </remarks>
-    IAsyncEnumerable<object?> SearchRecordsAsync(string sortField, bool ascending, CancellationToken cancellationToken, StringComparison comparison = StringComparison.OrdinalIgnoreCase, params IRecordFilter?[]? recordFilters);
+    IAsyncEnumerable<object?> SearchRecordsAsync(string? sortField, bool ascending, CancellationToken cancellationToken, StringComparison comparison = StringComparison.OrdinalIgnoreCase, params IRecordFilter?[]? recordFilters);
 
     /// <summary>
     /// Gets the specified <paramref name="page"/> of records from the provided source <paramref name="records"/> array.
@@ -1553,7 +1554,7 @@ public interface ITableOperations
     /// <remarks>
     /// <para>
     /// This method is intended to be used in conjunction with calls to the overloads for
-    /// <see cref="QueryRecords(string, bool, int, int, RecordRestriction[])"/> which are
+    /// <see cref="QueryRecords(string?, bool, int, int, RecordRestriction[])"/> which are
     /// used for record pagination.
     /// </para>
     /// <para>

--- a/src/Gemstone.Data/Model/PageSizeAttribute.cs
+++ b/src/Gemstone.Data/Model/PageSizeAttribute.cs
@@ -26,7 +26,7 @@ using System;
 namespace Gemstone.Data.Model;
 
 /// <summary>
-/// Defines an attribute that will allows a top number of results to be returned when queried
+/// Defines an attribute that will allow a top number of results to be returned when queried
 /// </summary>
 [AttributeUsage(AttributeTargets.Class)]
 public sealed class PageSizeAttribute : Attribute
@@ -34,10 +34,7 @@ public sealed class PageSizeAttribute : Attribute
     /// <summary>
     /// Gets field name to use for property.
     /// </summary>
-    public int Limit
-    {
-        get;
-    }
+    public int Limit { get; }
 
     /// <summary>
     /// Creates a new <see cref="PageSizeAttribute"/>.
@@ -45,6 +42,6 @@ public sealed class PageSizeAttribute : Attribute
     /// <param name="limit">Number of top records to return per Page.</param>
     public PageSizeAttribute(int limit)
     {
-            Limit = limit;
-        }
+        Limit = limit;
+    }
 }

--- a/src/Gemstone.Data/Model/ParentKeyAttribute.cs
+++ b/src/Gemstone.Data/Model/ParentKeyAttribute.cs
@@ -21,7 +21,6 @@
 //
 //******************************************************************************************************
 
-
 using System;
 
 namespace Gemstone.Data.Model;
@@ -35,10 +34,7 @@ public sealed class ParentKeyAttribute : Attribute
     /// <summary>
     /// Gets field name to use for property.
     /// </summary>
-    public Type Model
-    {
-        get;
-    }
+    public Type Model { get; }
 
     /// <summary>
     /// Creates a new <see cref="ParentKeyAttribute"/>.

--- a/src/Gemstone.Data/Model/PatchRolesAttribute.cs
+++ b/src/Gemstone.Data/Model/PatchRolesAttribute.cs
@@ -34,10 +34,7 @@ public sealed class PatchRolesAttribute : Attribute
     /// <summary>
     /// Gets field name to use for property.
     /// </summary>
-    public string Roles
-    {
-        get;
-    }
+    public string Roles { get; }
 
     /// <summary>
     /// Creates a new <see cref="PatchRolesAttribute"/>.

--- a/src/Gemstone.Data/Model/RecordOperationAttribute.cs
+++ b/src/Gemstone.Data/Model/RecordOperationAttribute.cs
@@ -95,7 +95,7 @@ public sealed class RecordOperationAttribute : Attribute
     /// <param name="operation">The <see cref="RecordOperation"/> the method represents.</param>
     public RecordOperationAttribute(Type modelType, RecordOperation operation)
     {
-            ModelType = modelType;
-            Operation = operation;
-        }
+        ModelType = modelType;
+        Operation = operation;
+    }
 }

--- a/src/Gemstone.Data/Model/RecordRestriction.cs
+++ b/src/Gemstone.Data/Model/RecordRestriction.cs
@@ -231,7 +231,10 @@ public class RecordRestriction : IEquatable<RecordRestriction>
     /// <c>null</c>, empty or whitespace and the other parameter's filter expression is defined, then
     /// the parameter that has a filter expression will be returned.
     /// </remarks>
-    public static RecordRestriction? operator +(RecordRestriction? left, RecordRestriction? right) => CombineAnd(left, right);
+    public static RecordRestriction? operator +(RecordRestriction? left, RecordRestriction? right)
+    {
+        return CombineAnd(left, right);
+    }
 
     /// <summary>
     /// Combines two record restrictions with an AND condition.
@@ -247,7 +250,10 @@ public class RecordRestriction : IEquatable<RecordRestriction>
     /// <c>null</c>, empty or whitespace and the other parameter's filter expression is defined, then
     /// the parameter that has a filter expression will be returned.
     /// </remarks>
-    public static RecordRestriction? operator &(RecordRestriction? left, RecordRestriction? right) => CombineAnd(left, right);
+    public static RecordRestriction? operator &(RecordRestriction? left, RecordRestriction? right)
+    {
+        return CombineAnd(left, right);
+    }
 
     /// <summary>
     /// Combines two record restrictions with an OR condition.
@@ -263,7 +269,10 @@ public class RecordRestriction : IEquatable<RecordRestriction>
     /// <c>null</c>, empty or whitespace and the other parameter's filter expression is defined, then
     /// the parameter that has a filter expression will be returned.
     /// </remarks>
-    public static RecordRestriction? operator |(RecordRestriction? left, RecordRestriction? right) => CombineOr(left, right);
+    public static RecordRestriction? operator |(RecordRestriction? left, RecordRestriction? right)
+    {
+        return CombineOr(left, right);
+    }
 
     #endregion
 
@@ -279,7 +288,7 @@ public class RecordRestriction : IEquatable<RecordRestriction>
     public static RecordRestriction? Clone(RecordRestriction? source)
     {
         if (source is null)
-            return default;
+            return null;
 
         object?[] parameters = source.Parameters;
 
@@ -306,7 +315,10 @@ public class RecordRestriction : IEquatable<RecordRestriction>
     /// <c>null</c>, empty or whitespace and the other parameter's filter expression is defined, then
     /// the parameter that has a filter expression will be returned.
     /// </remarks>
-    public static RecordRestriction? CombineAnd(RecordRestriction? left, RecordRestriction? right) => Combine(left, right, "AND");
+    public static RecordRestriction? CombineAnd(RecordRestriction? left, RecordRestriction? right)
+    {
+        return Combine(left, right, "AND");
+    }
 
     /// <summary>
     /// Combines two record restrictions with an OR condition.
@@ -322,14 +334,17 @@ public class RecordRestriction : IEquatable<RecordRestriction>
     /// <c>null</c>, empty or whitespace and the other parameter's filter expression is defined, then
     /// the parameter that has a filter expression will be returned.
     /// </remarks>
-    public static RecordRestriction? CombineOr(RecordRestriction? left, RecordRestriction? right) => Combine(left, right, "OR");
+    public static RecordRestriction? CombineOr(RecordRestriction? left, RecordRestriction? right)
+    {
+        return Combine(left, right, "OR");
+    }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static RecordRestriction? Combine(RecordRestriction? left, RecordRestriction? right, string operation)
     {
         // Check for null operands
         if (left is null && right is null)
-            return default;
+            return null;
 
         if (left is null)
             return right;

--- a/src/Gemstone.Data/Model/RootQueryRestrictionAttribute.cs
+++ b/src/Gemstone.Data/Model/RootQueryRestrictionAttribute.cs
@@ -110,7 +110,7 @@ public sealed class RootQueryRestrictionAttribute : Attribute
     public RootQueryRestrictionAttribute(string filterExpression, params object?[]? parameters)
     {
         FilterExpression = filterExpression ?? throw new ArgumentNullException(nameof(filterExpression));
-        Parameters = parameters ?? Array.Empty<object>();
+        Parameters = parameters ?? [];
     }
 
     #endregion

--- a/src/Gemstone.Data/Model/SearchExtensionAttribute.cs
+++ b/src/Gemstone.Data/Model/SearchExtensionAttribute.cs
@@ -26,13 +26,9 @@ using System;
 namespace Gemstone.Data.Model;
 
 /// <summary>
-/// Defines an attribute that marks methods that are used to transform <see cref="IRecordFilter"/> into <see cref="RecordRestriction"/>.
+/// Defines an attribute that marks static methods on a model that are used to transform
+/// <see cref="IRecordFilter"/> into <see cref="RecordRestriction"/>.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method)]
-public sealed class SearchExtensionAttribute(string fieldMatch) : Attribute
-{
-    /// <summary>
-    /// The string used to match FieldNames this applies to.
-    /// </summary>
-    public string FieldMatch { get; } = fieldMatch;
-}
+public sealed class SearchExtensionAttribute(string fieldMatch) :
+    ExtensionAttributeBase(fieldMatch);

--- a/src/Gemstone.Data/Model/SortExtensionAttribute.cs
+++ b/src/Gemstone.Data/Model/SortExtensionAttribute.cs
@@ -26,13 +26,9 @@ using System;
 namespace Gemstone.Data.Model;
 
 /// <summary>
-/// Defines an attribute that marks methods that are used to transform a Field into subquery for Sorting.
+/// Defines an attribute that marks static methods on a model that are used to transform a
+/// field into more complex order by expression, e.g., a subquery, for sorting.
 /// </summary>
 [AttributeUsage(AttributeTargets.Method)]
-public sealed class SortExtensionAttribute(string fieldMatch) : Attribute
-{
-    /// <summary>
-    /// The string used to match FieldNames this applies to.
-    /// </summary>
-    public string FieldMatch { get; } = fieldMatch;
-}
+public sealed class SortExtensionAttribute(string fieldMatch) : 
+    ExtensionAttributeBase(fieldMatch);

--- a/src/Gemstone.Data/Model/SortExtensionAttribute.cs
+++ b/src/Gemstone.Data/Model/SortExtensionAttribute.cs
@@ -1,0 +1,38 @@
+﻿//******************************************************************************************************
+//  SortExtensionAttribute.cs - Gbtc
+//
+//  Copyright © 2025, Grid Protection Alliance.  All Rights Reserved.
+//
+//  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
+//  the NOTICE file distributed with this work for additional information regarding copyright ownership.
+//  The GPA licenses this file to you under the MIT License (MIT), the "License"; you may
+//  not use this file except in compliance with the License. You may obtain a copy of the License at:
+//
+//      http://opensource.org/licenses/MIT
+//
+//  Unless agreed to in writing, the subject software distributed under the License is distributed on an
+//  "AS-IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. Refer to the
+//  License for the specific language governing permissions and limitations.
+//
+//  Code Modification History:
+//  ----------------------------------------------------------------------------------------------------
+//  03/22/2025 - C. Lackner
+//       Generated original version of source code.
+//
+//******************************************************************************************************
+
+using System;
+
+namespace Gemstone.Data.Model;
+
+/// <summary>
+/// Defines an attribute that marks methods that are used to transform a Field into subquery for Sorting.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class SortExtensionAttribute(string fieldMatch) : Attribute
+{
+    /// <summary>
+    /// The string used to match FieldNames this applies to.
+    /// </summary>
+    public string FieldMatch { get; } = fieldMatch;
+}

--- a/src/Gemstone.Data/Model/TableOperations.cs
+++ b/src/Gemstone.Data/Model/TableOperations.cs
@@ -76,16 +76,16 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     {
         [AllowNull]
         public string ConnectionString { get; set; }
-        public int ConnectionTimeout { get; } = default;
-        public string Database { get; } = default!;
+        public int ConnectionTimeout { get; } = 0;
+        public string Database { get; } = null!;
         public ConnectionState State { get; } = ConnectionState.Open;
         public void Open() {}
         public void Close() {}
         public void Dispose() {}
         public void ChangeDatabase(string databaseName) {}
-        public IDbCommand CreateCommand() => default!;
-        public IDbTransaction BeginTransaction() => default!;
-        public IDbTransaction BeginTransaction(IsolationLevel il) => default!;
+        public IDbCommand CreateCommand() => null!;
+        public IDbTransaction BeginTransaction() => null!;
+        public IDbTransaction BeginTransaction(IsolationLevel il) => null!;
     }
 
     private class IntermediateParameter : IDbDataParameter
@@ -116,7 +116,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     private const string TableNameSuffixToken = "<!TNS/>";
     private const string FieldListPrefixToken = "<!FLP/>";
     private const string FieldListSuffixToken = "<!FLS/>";
-    private const string WildcarChar = "%";
+    private const string DefaultWildcardChar = "%";
 
     // Fields
     private readonly string m_selectCountSql;
@@ -158,7 +158,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     /// customTokens = new[] { new KeyValuePair&lt;string, string&gt;("{count}", $"{count}") };
     /// </code>
     /// </remarks>
-    public TableOperations(AdoDataConnection connection, IEnumerable<KeyValuePair<string, string>>? customTokens = default)
+    public TableOperations(AdoDataConnection connection, IEnumerable<KeyValuePair<string, string>>? customTokens = null)
     {
         Connection = connection ?? throw new ArgumentNullException(nameof(connection));
         m_selectCountSql = s_selectCountSql;
@@ -356,7 +356,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     /// </para>
     /// </remarks>
     /// <exception cref="ArgumentNullException"><paramref name="connection"/> cannot be <c>null</c>.</exception>
-    public TableOperations(AdoDataConnection connection, Action<Exception> exceptionHandler, IEnumerable<KeyValuePair<string, string>>? customTokens = default)
+    public TableOperations(AdoDataConnection connection, Action<Exception> exceptionHandler, IEnumerable<KeyValuePair<string, string>>? customTokens = null)
         : this(connection, customTokens)
     {
         ExceptionHandler = exceptionHandler;
@@ -376,7 +376,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     public string UnescapedTableName => s_tableName;
 
     ///  <inheritdoc/>
-    public string WildcardChar => WildcarChar; 
+    public string WildcardChar { get; init; } = DefaultWildcardChar; 
 
     /// <inheritdoc/>
     public bool HasPrimaryKeyIdentityField => s_hasPrimaryKeyIdentityField;
@@ -725,7 +725,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     /// </remarks>
     public IEnumerable<T?> QueryRecords(string? orderByExpression = null, RecordRestriction? restriction = null, int limit = -1)
     {
-        orderByExpression = ProcessOrderBy(orderByExpression);
+        orderByExpression = ValidateOrderByExpression(orderByExpression);
 
         if (string.IsNullOrWhiteSpace(orderByExpression))
             orderByExpression = UpdateFieldNames(s_primaryKeyFields);
@@ -770,7 +770,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
 
             ExceptionHandler(opex);
 
-            return Enumerable.Empty<T>();
+            return [];
         }
     }
 
@@ -800,7 +800,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     /// </remarks>
     public IAsyncEnumerable<T?> QueryRecordsAsync(string? orderByExpression = null, RecordRestriction? restriction = null, int limit = -1, CancellationToken cancellationToken = default)
     {
-        orderByExpression = ProcessOrderBy(orderByExpression);
+        orderByExpression = ValidateOrderByExpression(orderByExpression);
 
         if (string.IsNullOrWhiteSpace(orderByExpression))
             orderByExpression = UpdateFieldNames(s_primaryKeyFields);
@@ -1162,13 +1162,12 @@ public class TableOperations<T> : ITableOperations where T : class, new()
         if (restrictions is not null)
             restriction = restrictions.Aggregate(restriction, (current, item) => current + item);
 
-        sortField = ProcessOrderBy(sortField);
+        sortField = ValidateOrderByExpression(sortField);
 
         if (string.IsNullOrWhiteSpace(sortField))
             sortField = s_fieldNames[s_primaryKeyProperties[0].Name];
 
-        if (sortField is null)
-            throw new ArgumentNullException(nameof(sortField));
+        ArgumentNullException.ThrowIfNull(sortField);
 
         bool sortFieldIsEncrypted = FieldIsEncrypted(sortField);
 
@@ -1223,7 +1222,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
 
                 ExceptionHandler(opex);
 
-                return Enumerable.Empty<T>();
+                return [];
             }
 
             m_lastSortField = sortField;
@@ -1274,14 +1273,13 @@ public class TableOperations<T> : ITableOperations where T : class, new()
         if (restrictions is not null) 
             restriction = restrictions.Aggregate(restriction, (current, item) => current + item);
 
-        sortField = ProcessOrderBy(sortField);
+        sortField = ValidateOrderByExpression(sortField);
 
         if (string.IsNullOrWhiteSpace(sortField))
             sortField = s_fieldNames[s_primaryKeyProperties[0].Name];
 
-        if (sortField is null)
-            throw new ArgumentNullException(nameof(sortField));
-
+        ArgumentNullException.ThrowIfNull(sortField);
+        
         bool sortFieldIsEncrypted = FieldIsEncrypted(sortField);
 
         // Records that have been deleted since primary key cache was established will return null and be filtered out which will throw
@@ -1503,12 +1501,12 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     /// through them using the <see cref="GetPageOfRecords"/> function. As a result, usage should be restricted to smaller data sets. 
     /// </para>
     /// </remarks>
-    public T?[]? SearchRecords(string sortField, bool ascending, StringComparison comparison = StringComparison.OrdinalIgnoreCase, params IRecordFilter?[]? recordFilters)
+    public T?[]? SearchRecords(string? sortField, bool ascending, StringComparison comparison = StringComparison.OrdinalIgnoreCase, params IRecordFilter?[]? recordFilters)
     {
         if (recordFilters is null)
             return null;
 
-        sortField = ProcessOrderBy(sortField);
+        sortField = ValidateOrderByExpression(sortField);
 
         if (string.IsNullOrWhiteSpace(sortField))
             sortField = s_fieldNames[s_primaryKeyProperties[0].Name];
@@ -1530,7 +1528,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     }
 
     // ReSharper disable once CoVariantArrayConversion
-    object?[]? ITableOperations.SearchRecords(string sortField, bool ascending, StringComparison comparison, params IRecordFilter?[]? recordFilter)
+    object?[]? ITableOperations.SearchRecords(string? sortField, bool ascending, StringComparison comparison, params IRecordFilter?[]? recordFilter)
     {
         return SearchRecords(sortField, ascending, comparison, recordFilter);
     }
@@ -1559,12 +1557,12 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     /// through them using the <see cref="GetPageOfRecordsAsync"/> function. As a result, usage should be restricted to smaller data sets. 
     /// </para>
     /// </remarks>
-    public IAsyncEnumerable<T?> SearchRecordsAsync(string sortField, bool ascending, CancellationToken cancellationToken, StringComparison comparison = StringComparison.OrdinalIgnoreCase, params IRecordFilter?[]? recordFilters)
+    public IAsyncEnumerable<T?> SearchRecordsAsync(string? sortField, bool ascending, CancellationToken cancellationToken, StringComparison comparison = StringComparison.OrdinalIgnoreCase, params IRecordFilter?[]? recordFilters)
     {
         if (recordFilters is null)
             return AsyncEnumerable.Empty<T?>();
 
-        sortField = ProcessOrderBy(sortField);
+        sortField = ValidateOrderByExpression(sortField);
 
         if (string.IsNullOrWhiteSpace(sortField))
             sortField = s_fieldNames[s_primaryKeyProperties[0].Name];
@@ -1584,7 +1582,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
             queryResult;
     }
 
-    IAsyncEnumerable<object?> ITableOperations.SearchRecordsAsync(string sortField, bool ascending, CancellationToken cancellationToken, StringComparison comparison, params IRecordFilter?[]? recordFilter)
+    IAsyncEnumerable<object?> ITableOperations.SearchRecordsAsync(string? sortField, bool ascending, CancellationToken cancellationToken, StringComparison comparison, params IRecordFilter?[]? recordFilter)
     {
         return SearchRecordsAsync(sortField, ascending, cancellationToken, comparison, recordFilter)!.Cast<object?>();
     }
@@ -1646,7 +1644,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     {
         try
         {
-            return Connection.TryRetrieveRow(m_selectRowSql, out DataRow? row, GetInterpretedPrimaryKeys(primaryKeys)) ? LoadRecord(row!) : default;
+            return Connection.TryRetrieveRow(m_selectRowSql, out DataRow? row, GetInterpretedPrimaryKeys(primaryKeys)) ? LoadRecord(row!) : null;
 
         }
         catch (Exception ex)
@@ -1678,7 +1676,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
         try
         {
             (DataRow? row, bool success) = await Connection.TryRetrieveRowAsync(m_selectRowSql, cancellationToken, GetInterpretedPrimaryKeys(primaryKeys)).ConfigureAwait(false);
-            return success ? LoadRecord(row!) : default;
+            return success ? LoadRecord(row!) : null;
 
         }
         catch (Exception ex)
@@ -1704,7 +1702,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     {
         try
         {
-            return Connection.TryRetrieveRow(m_selectRowSql, out DataRow? row, GetInterpretedPrimaryKeys(primaryKeys, true)) ? LoadRecord(row!, properties ?? s_properties.Values) : default;
+            return Connection.TryRetrieveRow(m_selectRowSql, out DataRow? row, GetInterpretedPrimaryKeys(primaryKeys, true)) ? LoadRecord(row!, properties ?? s_properties.Values) : null;
 
         }
         catch (Exception ex)
@@ -1726,7 +1724,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
         try
         {
             (DataRow? row, bool success) = await Connection.TryRetrieveRowAsync(m_selectRowSql, cancellationToken, GetInterpretedPrimaryKeys(primaryKeys, true)).ConfigureAwait(false);
-            return success ? LoadRecord(row!, properties ?? s_properties.Values) : default;
+            return success ? LoadRecord(row!, properties ?? s_properties.Values) : null;
 
         }
         catch (Exception ex)
@@ -1978,8 +1976,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     /// <inheritdoc/>
     public int DeleteRecord(RecordRestriction? restriction, bool? applyRootQueryRestriction = null)
     {
-        if (restriction is null)
-            throw new ArgumentNullException(nameof(restriction));
+        ArgumentNullException.ThrowIfNull(restriction);
 
         string? sqlExpression = null;
 
@@ -2012,8 +2009,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     /// <inheritdoc/>
     public async Task<int> DeleteRecordAsync(RecordRestriction? restriction, CancellationToken cancellationToken, bool? applyRootQueryRestriction = null)
     {
-        if (restriction is null)
-            throw new ArgumentNullException(nameof(restriction));
+        ArgumentNullException.ThrowIfNull(restriction);
 
         string? sqlExpression = null;
 
@@ -2600,7 +2596,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
         if (s_propertyNames.TryGetValue(fieldName, out string? propertyName) && s_properties.TryGetValue(propertyName, out PropertyInfo? property) && property.TryGetAttribute(out attribute))
             return true;
 
-        attribute = default!;
+        attribute = null!;
 
         return false;
     }
@@ -2608,13 +2604,13 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     /// <inheritdoc/>
     public bool TryGetFieldAttribute(string fieldName, Type attributeType, out Attribute? attribute)
     {
-        if (!attributeType.IsInstanceOfType(typeof(Attribute)))
+        if (!typeof(Attribute).IsAssignableFrom(attributeType))
             throw new ArgumentException($"The specified type \"{attributeType.Name}\" is not an Attribute.", nameof(attributeType));
 
         if (s_propertyNames.TryGetValue(fieldName, out string? propertyName) && s_properties.TryGetValue(propertyName, out PropertyInfo? property) && property.TryGetAttribute(attributeType, out attribute))
             return true;
 
-        attribute = default;
+        attribute = null;
 
         return false;
     }
@@ -2677,55 +2673,13 @@ public class TableOperations<T> : ITableOperations where T : class, new()
         if (s_propertyNames.TryGetValue(fieldName, out string? propertyName) && s_properties.TryGetValue(propertyName, out PropertyInfo? property))
             return property.PropertyType;
 
-        return default;
+        return null;
     }
 
-    /// <summary>
-    /// Checks if an expression is either a valid field in the model or explcitly allowed via the <see cref="SortExtensionAttribute"/>
-    /// </summary>
-    /// <param name="orderByExpression"> The Expression to be checked. This does include ASC or DESC.</param>
-    /// <returns> a new <see cref="string"/> to be used in the database query.</returns>
-    /// <exception cref="InvalidExpressionException">The exception thrown if the <see param="orderByExpression"/> is not valid.</exception>
-    private string ProcessOrderBy(string orderByExpression)
-    {
-        if (string.IsNullOrWhiteSpace(orderByExpression))
-            return orderByExpression;
-
-        List<string> parsedExpressions = new List<string>();
-        IEnumerable<MethodInfo> methods = typeof(T).GetMethods(BindingFlags.Public | BindingFlags.Static);
-
-        foreach (string field in orderByExpression.Split(','))
-        {
-            string fld = field.Trim();
-            if (fld.EndsWith("ASC", StringComparison.OrdinalIgnoreCase))
-                fld = fld.Remove(0, fld.Length - 3).Trim();
-            if (fld.EndsWith("DESC", StringComparison.OrdinalIgnoreCase))
-                fld = fld.Remove(0, fld.Length - 4).Trim();
-
-            if (methods.Any(info =>
-                info.TryGetAttribute(out SortExtensionAttribute? sortExtension) &&
-                Regex.IsMatch(fld, sortExtension.FieldMatch)))
-            {
-                parsedExpressions.Add((string)methods.Where(info =>
-                info.TryGetAttribute(out SortExtensionAttribute? sortExtension) &&
-                Regex.IsMatch(fld, sortExtension.FieldMatch)).FirstOrDefault()!.Invoke(null, new object[] { field }));
-
-                continue;
-            }
-            if (FieldExists(fld))
-                parsedExpressions.Add(field);
-            else
-                throw new InvalidExpressionException($"\"{field}\" is not a valid {nameof(orderByExpression)}");
-        }
-
-        return string.Join(", ", parsedExpressions);
-
-    }
-    
     /// <inheritdoc/>
     public bool FieldExists(string fieldName)
     {
-        return s_propertyNames.TryGetValue(fieldName, out _);
+        return s_validFieldNames.Contains(fieldName);
     }
 
     /// <inheritdoc/>
@@ -2829,15 +2783,14 @@ public class TableOperations<T> : ITableOperations where T : class, new()
 
     // Derive field name, unescaping it if it was escaped by the model
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private string GetUnescapedFieldName(string fieldName)
+    private static string GetUnescapedFieldName(string fieldName)
     {
         if (s_escapedFieldNameTargets is null)
             return fieldName;
 
-        if (!s_escapedFieldNameTargets.TryGetValue(fieldName, out _))
-            return fieldName;
-
-        return fieldName.Substring(1, fieldName.Length - 2);
+        return s_escapedFieldNameTargets.TryGetValue(fieldName, out _) ? 
+            fieldName.Substring(1, fieldName.Length - 2) : 
+            fieldName;
     }
 
     // Update field names in expression, escaping or unescaping as needed as defined by model
@@ -2845,7 +2798,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     private string? UpdateFieldNames(string? filterExpression)
     {
         if (filterExpression is null)
-            return default;
+            return null;
 
         if (s_escapedFieldNameTargets is not null)
         {
@@ -2881,7 +2834,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private IEnumerable<T?> LocalOrderBy(IEnumerable<T?> queryResults, string sortField, bool ascending, StringComparer? comparer = default)
+    private IEnumerable<T?> LocalOrderBy(IEnumerable<T?> queryResults, string sortField, bool ascending, StringComparer? comparer = null)
     {
         // Execute order-by locally on unencrypted data
         return ascending ?
@@ -2890,12 +2843,82 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private IAsyncEnumerable<T?> LocalOrderByAsync(IAsyncEnumerable<T?> queryResults, string sortField, bool ascending, StringComparer? comparer = default)
+    private IAsyncEnumerable<T?> LocalOrderByAsync(IAsyncEnumerable<T?> queryResults, string sortField, bool ascending, StringComparer? comparer = null)
     {
         // Execute order-by locally on unencrypted data
         return ascending ?
             queryResults.OrderBy(record => GetFieldValue(record, sortField) as string, comparer ?? StringComparer.OrdinalIgnoreCase) :
             queryResults.OrderByDescending(record => GetFieldValue(record, sortField) as string, comparer ?? StringComparer.OrdinalIgnoreCase);
+    }
+
+    // Validates that an order by expression is either an explicitly allowed via the 'SortExtensionAttribute' or a field in the model 
+    private string? ValidateOrderByExpression(string? orderByExpression)
+    {
+        if (string.IsNullOrWhiteSpace(orderByExpression))
+            return orderByExpression;
+
+        // Split the expression by commas to handle multiple fields
+        string[] fieldExpressions = orderByExpression.Split(',');
+        List<string> validatedExpressions = [];
+
+        foreach (string fieldExpression in fieldExpressions)
+        {
+            string trimmedExpression = fieldExpression.Trim();
+
+            if (string.IsNullOrWhiteSpace(trimmedExpression))
+                continue;
+
+            // Parse the field name and any optional direction (ASC/DESC)
+            string fieldName, direction;
+
+            // Check for ASC/DESC keywords
+            if (trimmedExpression.EndsWith(" ASC", StringComparison.OrdinalIgnoreCase))
+            {
+                fieldName = trimmedExpression[..^4].Trim();
+                direction = " ASC";
+            }
+            else if (trimmedExpression.EndsWith(" DESC", StringComparison.OrdinalIgnoreCase))
+            {
+                fieldName = trimmedExpression[..^5].Trim();
+                direction = " DESC";
+            }
+            else
+            {
+                // No direction specified
+                fieldName = trimmedExpression;
+                direction = string.Empty;
+            }
+
+            // Check if the field matches any SortExtension pre-compiled regex patterns
+            bool matchFound = false;
+
+            foreach ((Regex fieldMatchExpression, Func<string, string> sortExtensionMethod) in s_sortExtensions)
+            {
+                if (!fieldMatchExpression.IsMatch(fieldName))
+                    continue;
+
+                // Call the delegate method to get the coded order by expression
+                string expression = sortExtensionMethod(fieldName);
+                validatedExpressions.Add(expression + direction);
+                matchFound = true;
+
+                // Exit after first match, possible duplicate field matches are ignored - models with wide
+                // field match expression should ensure that the most specific expressions are listed first
+                break;
+            }
+
+            if (matchFound)
+                continue;
+
+            // If no SortExtension method matches, check if it's a valid field in the model
+            if (!FieldExists(fieldName))
+                throw new InvalidExpressionException($"\"{fieldName}\" is not a valid field in the order by expression");
+
+            validatedExpressions.Add(fieldName + direction);
+        }
+
+        // Combine all validated expressions back with commas
+        return string.Join(", ", validatedExpressions);
     }
 
     #endregion
@@ -2934,6 +2957,10 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     private static readonly Action<CurrentScope> s_updateRecordInstance;
     private static readonly Action<CurrentScope> s_applyRecordDefaults;
     private static readonly DataTable s_tableSchema;
+    private static readonly HashSet<string> s_validFieldNames;
+    private static readonly HashSet<string> s_searchableFields;
+    private static readonly (Regex, Func<IRecordFilter, RecordRestriction>)[] s_searchExtensions;
+    private static readonly (Regex, Func<string, string>)[] s_sortExtensions;
     private static TypeRegistry? s_typeRegistry;
 
     // Static Constructor
@@ -3140,13 +3167,72 @@ public class TableOperations<T> : ITableOperations where T : class, new()
             }
 
             // Create the DataColumn with the non-nullable type
-            DataColumn column = new DataColumn(fieldName, columnType)
-            {
-                AllowDBNull = isNullable
-            };
+            DataColumn column = new(fieldName, columnType) { AllowDBNull = isNullable };
 
             s_tableSchema.Columns.Add(column);
         }
+
+        // Create hash set of valid field names, escaped and unescaped
+        s_validFieldNames = new HashSet<string>(s_fieldNames.Values, StringComparer.OrdinalIgnoreCase);
+        s_validFieldNames.UnionWith(s_fieldNames.Values.Select(GetUnescapedFieldName));
+
+        // Create hash set of searchable fields
+        s_searchableFields = new HashSet<string>(typeof(T).GetCustomAttributes<SearchableAttribute>().SelectMany(attr => attr.FieldNames), StringComparer.OrdinalIgnoreCase);
+
+        // Get all public static methods for the modeled table
+        MethodInfo[] staticMethods = typeof(T).GetMethods(BindingFlags.Public | BindingFlags.Static);
+
+        // Resolve extensions methods for the modeled table
+        s_searchExtensions = ResolveExtensionAttributes<SearchExtensionAttribute, IRecordFilter, RecordRestriction>(staticMethods);
+        s_sortExtensions = ResolveExtensionAttributes<SortExtensionAttribute, string, string>(staticMethods);
+    }
+
+    internal static bool IsSearchableField(string fieldName)
+    {
+        return s_searchableFields.Contains(fieldName);
+    }
+
+    private static (Regex, Func<TInput, TReturn>)[] ResolveExtensionAttributes<TAttribute, TInput, TReturn>(MethodInfo[] staticMethods) where TAttribute : ExtensionAttributeBase
+    {
+        List<(Regex, Func<TInput, TReturn>)> extensions = [];
+
+        foreach (MethodInfo method in staticMethods)
+        {
+            TAttribute? attribute = method.GetCustomAttribute<TAttribute>();
+
+            if (attribute is null)
+                continue;
+
+            // Validate method signature
+            ParameterInfo[] parameters = method.GetParameters();
+
+            if (method.ReturnType != typeof(TReturn) || parameters.Length != 1 || parameters[0].ParameterType != typeof(string))
+            {
+                throw new InvalidOperationException(
+                    $"Method \"{method.Name}\" marked with \"{typeof(TAttribute).Name}\" in model \"{typeof(T).Name}\" has an invalid signature. " +
+                    $"Expected: public static {typeof(TReturn).Name} Method({typeof(TInput)} input)");
+            }
+
+            // Compile the regex pattern
+            Regex regex = new(attribute.FieldMatch, RegexOptions.Compiled);
+
+            // Create and cache the delegate directly as Func<string, string>
+            Func<TInput, TReturn> staticExtensionMethod = (Func<TInput, TReturn>)Delegate.CreateDelegate(typeof(Func<TInput, TReturn>), method);
+            extensions.Add((regex, staticExtensionMethod));
+        }
+
+        return extensions.ToArray();
+    }
+
+    internal static Func<IRecordFilter, RecordRestriction>? GetSearchExtensionMethod(string fieldName)
+    {
+        foreach ((Regex fieldMatchExpression, Func<IRecordFilter, RecordRestriction> searchExtensionMethod) in s_searchExtensions)
+        {
+            if (fieldMatchExpression.IsMatch(fieldName))
+                return searchExtensionMethod;
+        }
+
+        return null;
     }
 
     // Static Properties
@@ -3178,7 +3264,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     /// </remarks>
     public static Func<DataRow, T?> LoadRecordFunction()
     {
-        using AdoDataConnection connection = new(default!, typeof(NullConnection));
+        using AdoDataConnection connection = new(null!, typeof(NullConnection));
         return new TableOperations<T>(connection).LoadRecord;
     }
 
@@ -3193,7 +3279,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     /// </remarks>
     public static Func<T?> NewRecordFunction()
     {
-        using AdoDataConnection connection = new(default!, typeof(NullConnection));
+        using AdoDataConnection connection = new(null!, typeof(NullConnection));
         return new TableOperations<T>(connection).NewRecord;
     }
 
@@ -3208,7 +3294,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     /// </remarks>
     public static Action<T> ApplyRecordDefaultsFunction()
     {
-        using AdoDataConnection connection = new(default!, typeof(NullConnection));
+        using AdoDataConnection connection = new(null!, typeof(NullConnection));
         return new TableOperations<T>(connection).ApplyRecordDefaults;
     }
 
@@ -3223,7 +3309,7 @@ public class TableOperations<T> : ITableOperations where T : class, new()
     /// </remarks>
     public static Action<T> ApplyRecordUpdatesFunction()
     {
-        using AdoDataConnection connection = new(default!, typeof(NullConnection));
+        using AdoDataConnection connection = new(null!, typeof(NullConnection));
         return new TableOperations<T>(connection).ApplyRecordUpdates;
     }
 

--- a/src/Gemstone.Data/Model/ValueLabel.cs
+++ b/src/Gemstone.Data/Model/ValueLabel.cs
@@ -20,35 +20,25 @@
 //       Generated original version of source code.
 //
 //******************************************************************************************************
-// ReSharper disable StaticMemberInGenericType
-// ReSharper disable RedundantCatchClause
-
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Text.RegularExpressions;
-using Gemstone.Reflection.MemberInfoExtensions;
 
 namespace Gemstone.Data.Model;
 
 /// <summary>
-/// Defines a common model to hold a Label and associated Value.
+/// Defines a common model to hold a label and associated value.
 /// </summary>
 public class ValueLabel
 {
     #region [ Properties ]
 
     /// <summary>
-    /// gets or sets the Value Property.
+    /// Gets or sets the value property.
     /// </summary>
     public string Value { get; set; } = string.Empty;
 
     /// <summary>
-    /// gets or sets the Label Property.
+    /// Gets or sets the label property.
     /// </summary>
     public string Label { get; set; } = string.Empty;
 
     #endregion
-
 }

--- a/src/Gemstone.Data/Schema.cs
+++ b/src/Gemstone.Data/Schema.cs
@@ -631,7 +631,7 @@ public class Field : IComparable
                             break;
                         case OleDbType.Guid:
                             if (encodedValue.Length == 0)
-                                encodedValue = new Guid().ToString().ToLower();
+                                encodedValue = Guid.Empty.ToString().ToLower();
 
                             encodedValue = Parent.Parent.Parent.Parent.DataSourceType == DatabaseType.Access ? $"{{{encodedValue.ToLower()}}}" : $"'{encodedValue.ToLower()}'";
 
@@ -722,7 +722,7 @@ public class Field : IComparable
 
                     break;
                 case OleDbType.Guid:
-                    encodedValue = new Guid().ToString().ToLower();
+                    encodedValue = Guid.Empty.ToString().ToLower();
                     if (Parent.Parent.Parent.Parent.DataSourceType == DatabaseType.Access)
                         encodedValue = $"{{{encodedValue}}}";
                     else
@@ -826,7 +826,7 @@ public class ForeignKeyFields : IEnumerable
     {
         Parent = parent;
         FieldDictionary = new Dictionary<string, ForeignKeyField>(StringComparer.OrdinalIgnoreCase);
-        FieldsList = new List<ForeignKeyField>();
+        FieldsList = [];
     }
 
     #endregion
@@ -931,7 +931,7 @@ public class Fields : IEnumerable<Field>
     {
         Parent = parent;
         FieldDictionary = new Dictionary<string, Field>(StringComparer.OrdinalIgnoreCase);
-        FieldList = new List<Field>();
+        FieldList = [];
     }
 
     #endregion
@@ -1366,7 +1366,7 @@ public class Table : IComparable, IComparable<Table>
     {
         Table table;
 
-        tableStack ??= new List<Table>();
+        tableStack ??= [];
 
         tableStack.Add(this);
 
@@ -1475,7 +1475,7 @@ public class Table : IComparable, IComparable<Table>
         Table? remoteForeignKeyTable = m_parent[foreignKeyTableName];
         Field? remoteForeignKeyField = remoteForeignKeyTable?.Fields[foreignKeyFieldName];
 
-        if (remoteForeignKeyField == null)
+        if (remoteForeignKeyField is null)
             return false;
                 
         ForeignKeyField localForeignKeyField = new(localPrimaryKeyField.ForeignKeys);
@@ -1576,7 +1576,7 @@ public class Tables : IEnumerable<Table>
         // We only allow internal creation of this object
         m_parent = parent;
         TableDictionary = new Dictionary<string, Table>(StringComparer.OrdinalIgnoreCase);
-        TableList = new List<Table>();
+        TableList = [];
     }
 
     #endregion
@@ -1970,7 +1970,7 @@ public class Schema
                 m_schemaConnection.ExecuteNonQuery("SET sql_mode='ANSI_QUOTES'");
 
             // Validate table / field existence against open connection as defined in serialized schema
-            List<Table> tablesToRemove = new();
+            List<Table> tablesToRemove = [];
 
             foreach (Table table in Tables)
             {
@@ -1979,7 +1979,7 @@ public class Schema
                     // Make sure table exists
                     m_schemaConnection.ExecuteScalar($"SELECT COUNT(*) FROM {table.SQLEscapedName}");
 
-                    List<Field> fieldsToRemove = new();
+                    List<Field> fieldsToRemove = [];
                     string testFieldSQL;
 
                     try


### PR DESCRIPTION
This PR adds validation to `TableOperations` to only allow orderBy Fields that are either Properties in the Model or explicit defined.

Example of explicitly defined Fields:
```
class Device
{
   public int CompanyID {get; set; }
   
   [SortExtension("Company")]
   public static string CompanySort(string expression)
   {
      bool addDesc = expression.EndsWith("DESC", StringComparison.OrdinalIgnoreCase);
      return "(SELECT SortOrder FROM Company WHERE Company.ID = Device.CompanyID)" + (addDesc? "" : " DESC");
   }
}
```
** Note ** An explicit definition via `SortExtension` will override ordering by a Property. 